### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/src/src/api/endpoints/Application.ts
+++ b/src/src/api/endpoints/Application.ts
@@ -46,7 +46,7 @@ async function findApplicationOrThrowError(id: unknown, res: Response<Applicatio
             return null;
         }
     } catch (e) {
-        console.error("Exception occurred:", e);
+        logger.error("Exception occurred:", e);
         res.status(500).send({ message: 'An internal server error occurred' });
         return null;
     }

--- a/src/src/api/endpoints/Application.ts
+++ b/src/src/api/endpoints/Application.ts
@@ -46,7 +46,8 @@ async function findApplicationOrThrowError(id: unknown, res: Response<Applicatio
             return null;
         }
     } catch (e) {
-        res.status(500).send(e);
+        console.error("Exception occurred:", e);
+        res.status(500).send({ message: 'An internal server error occurred' });
         return null;
     }
 }

--- a/src/src/api/endpoints/Application.ts
+++ b/src/src/api/endpoints/Application.ts
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import { Application } from '../../db/entities/Application';
 import {mwHasSystemPrivilege} from "../../services/Authentication";
 import {ErrorResponse} from "../utils/DefaultResponses";
+import {logger} from "../../logger";
 
 // Define the shape of the body for POST and PUT requests
 interface PostRequestBody {


### PR DESCRIPTION
Potential fix for [https://github.com/TerraTex-Community/Webhook-Scheduler/security/code-scanning/1](https://github.com/TerraTex-Community/Webhook-Scheduler/security/code-scanning/1)

To fix the problem, we need to modify the code to log the stack trace on the server and send a generic error message to the client. This involves:
1. Adding a logging mechanism to capture the stack trace.
2. Modifying the catch block to log the error and send a generic error message to the client.

We will use the `console.error` method to log the stack trace on the server. This is a simple and effective way to capture the error details without exposing them to the client.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
