### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -46,7 +46,8 @@
     "typescript": "^5.4.3",
     "uuid": "^9.0.1",
     "validator": "^13.12.0",
-    "winston": "^3.13.0"
+    "winston": "^3.13.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9",

--- a/src/src/api/endpoints/Job.ts
+++ b/src/src/api/endpoints/Job.ts
@@ -1,5 +1,6 @@
 // Import necessary modules from their relative paths
 import express, { Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import { Job, JobExecutionType } from '../../db/entities/Job';
 import { Application } from '../../db/entities/Application';
 import { v4 as uuidv4 } from 'uuid';
@@ -30,6 +31,15 @@ interface GetQuery {
 
 // Initialize new router instance
 const router = express.Router();
+
+// Configure rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
+// Apply rate limiter to all job-related endpoints
+router.use(limiter);
 
 /**
  * Utility function to validate the job execution type.


### PR DESCRIPTION
Potential fix for [https://github.com/TerraTex-Community/Webhook-Scheduler/security/code-scanning/5](https://github.com/TerraTex-Community/Webhook-Scheduler/security/code-scanning/5)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to achieve this is by using the `express-rate-limit` package, which allows us to set a maximum number of requests that can be made to the server within a specified time window. This will help mitigate the risk of denial-of-service attacks.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Configure a rate limiter with appropriate settings (e.g., maximum 100 requests per 15 minutes).
4. Apply the rate limiter to the router handling the job-related endpoints.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
